### PR TITLE
chore: move artifact publishing to build job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,11 +1,9 @@
 name: "Continuous Integration / Deployment"
   
 on:
-  push:
-    branches: ["main"]
-
   pull_request:
-    branches: ["main"]
+  push:
+    branches: [ $default-branch ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -46,6 +44,16 @@ jobs:
     - name: Webpack Build
       run: npm run build
 
+    - name: Setup Pages
+      if: github.event_name == 'push'
+      uses: actions/configure-pages@v3
+
+    - name: Upload artifact
+      if: github.event_name == 'push'
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: './dist'
+
   deploy:
     needs: build
 
@@ -58,14 +66,6 @@ jobs:
     if: github.event_name == 'push'
 
     steps:
-      - name: Setup Pages
-        uses: actions/configure-pages@v3
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
-        with:
-          path: './dist'
-
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1


### PR DESCRIPTION
The previous implemntation failed the deploy
workflow once the PR was merged. This change
is following an example found here:

https://github.com/actions/starter-workflows/blob/main/pages/nextjs.yml

Refs: #8