### PR TITLE
chore: refactor push trigger to main branch

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -3,7 +3,7 @@ name: "Continuous Integration / Deployment"
 on:
   pull_request:
   push:
-    branches: [ $default-branch ]
+    branches: [ "main" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
The $default-branch was not triggering the
push event for the actual default branch
(i.e., main).

Refs: #8