### PR TITLE
fix: remove asset prefix in hrefs

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -27,13 +27,11 @@ export default function Home() {
           name="google-site-verification"
           content="5n2Yycpl5i4z-4FFdBKeun_z9Fpsw9w6Vu-6pvyp3Rg"
         />
-        <link rel="icon" href="personal-portfolio/favicon.ico" />
+        <link rel="icon" href="/favicon.ico" />
       </Head>
       <Main>
         <MainAppBar />
-        <Jumbotron src="personal-portfolio/notebook.jpg">
-          Personal Portfolio
-        </Jumbotron>
+        <Jumbotron src="/notebook.jpg">Personal Portfolio</Jumbotron>
         <Welcome />
         <Projects />
         <WebProjects />


### PR DESCRIPTION
The jumbotron and favicon were not loading when
deployed to GitHub pages. This change does
break the local development implemenation for
these files, but due to time constraints, we
are moving forward with fixing the production
deployment.