### PR TITLE
fix: static asset prefix pathing

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,9 @@
+const isProd = process.env.NODE_ENV === "production";
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "export",
-  basePath: "/personal-portfolio",
+  assetPrefix: isProd ? "/personal-portfolio" : "",
   reactStrictMode: true,
 };
 

--- a/src/components/home/Footer.tsx
+++ b/src/components/home/Footer.tsx
@@ -39,10 +39,7 @@ export const Footer: FC = () => {
           paddingY={3}
         >
           <Box display="flex" gap={1} minWidth={200}>
-            <Avatar
-              alt="Hayden Phothong"
-              src="/personal-portfolio/profile.jpg"
-            />
+            <Avatar alt="Hayden Phothong" src="profile.jpg" />
             <Box display="flex" flexDirection="column">
               <Typography>Hayden Phothong</Typography>
               <Typography variant="caption">Software Engineer</Typography>
@@ -64,7 +61,7 @@ export const Footer: FC = () => {
             <Box display="flex" gap={1} alignItems="center">
               <PictureAsPdf />
               <Link
-                href="/personal-portfolio/Résumé_Hayden_Phothong.pdf"
+                href="Résumé_Hayden_Phothong.pdf"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/components/home/Welcome.tsx
+++ b/src/components/home/Welcome.tsx
@@ -15,7 +15,7 @@ export const Welcome: FC = () => (
       storage/retrieval, as well as the publishing process for the App Store and
       Play Store. If you would like to see my work history, check out my&nbsp;
       <Link
-        href="personal-portfolio/Résumé_Hayden_Phothong.pdf"
+        href="Résumé_Hayden_Phothong.pdf"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -27,13 +27,11 @@ export default function Home() {
           name="google-site-verification"
           content="5n2Yycpl5i4z-4FFdBKeun_z9Fpsw9w6Vu-6pvyp3Rg"
         />
-        <link rel="icon" href="personal-portfolio/favicon.ico" />
+        <link rel="icon" href="/favicon.ico" />
       </Head>
       <Main>
         <MainAppBar />
-        <Jumbotron src="personal-portfolio/notebook.jpg">
-          Personal Portfolio
-        </Jumbotron>
+        <Jumbotron src="/notebook.jpg">Personal Portfolio</Jumbotron>
         <Welcome />
         <Projects />
         <WebProjects />


### PR DESCRIPTION
This should be the actual fix for the static
assets in the GitHub Pages deployment. This fix
also allows the development server to work
correctly. We have removed the `basePath` option
in favor of prepending the `assetPrefix` when
we are in production.