### PR TITLE
revert: change back to using basePath instead of assetPrefix

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,7 @@
-const isProd = process.env.NODE_ENV === "production";
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "export",
-  assetPrefix: isProd ? "/personal-portfolio" : "",
+  basePath: "/personal-portfolio",
   reactStrictMode: true,
 };
 

--- a/src/components/home/Footer.tsx
+++ b/src/components/home/Footer.tsx
@@ -39,7 +39,10 @@ export const Footer: FC = () => {
           paddingY={3}
         >
           <Box display="flex" gap={1} minWidth={200}>
-            <Avatar alt="Hayden Phothong" src="profile.jpg" />
+            <Avatar
+              alt="Hayden Phothong"
+              src="/personal-portfolio/profile.jpg"
+            />
             <Box display="flex" flexDirection="column">
               <Typography>Hayden Phothong</Typography>
               <Typography variant="caption">Software Engineer</Typography>
@@ -61,7 +64,7 @@ export const Footer: FC = () => {
             <Box display="flex" gap={1} alignItems="center">
               <PictureAsPdf />
               <Link
-                href="Résumé_Hayden_Phothong.pdf"
+                href="/personal-portfolio/Résumé_Hayden_Phothong.pdf"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/components/home/Welcome.tsx
+++ b/src/components/home/Welcome.tsx
@@ -1,8 +1,7 @@
 import React, { FC } from "react";
 import { Section } from "../common/Section";
 import { WavingHand } from "@mui/icons-material";
-import Link from "next/link";
-import { Typography } from "@mui/material";
+import { Typography, Link } from "@mui/material";
 import { personalLinkedInURL } from "@/constants";
 
 export const Welcome: FC = () => (
@@ -15,7 +14,7 @@ export const Welcome: FC = () => (
       storage/retrieval, as well as the publishing process for the App Store and
       Play Store. If you would like to see my work history, check out my&nbsp;
       <Link
-        href="Résumé_Hayden_Phothong.pdf"
+        href="/personal-portfolio/Résumé_Hayden_Phothong.pdf"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -27,11 +27,13 @@ export default function Home() {
           name="google-site-verification"
           content="5n2Yycpl5i4z-4FFdBKeun_z9Fpsw9w6Vu-6pvyp3Rg"
         />
-        <link rel="icon" href="/favicon.ico" />
+        <link rel="icon" href="/personal-portfolio/favicon.ico" />
       </Head>
       <Main>
         <MainAppBar />
-        <Jumbotron src="/notebook.jpg">Personal Portfolio</Jumbotron>
+        <Jumbotron src="/personal-portfolio/notebook.jpg">
+          Personal Portfolio
+        </Jumbotron>
         <Welcome />
         <Projects />
         <WebProjects />


### PR DESCRIPTION
The `basePath` implementation was correct. We simply did not need to add both the `basePath` and the `assetPrefix` configurations. The documentation for Next.js states that with the use of `basePath`, we will need to provide that value to our `href` and `src` attributes.