### PR TITLE
fix: npm and yarn icon sizing

### DIFF
--- a/src/components/common/project/Project.tsx
+++ b/src/components/common/project/Project.tsx
@@ -27,11 +27,11 @@ export const Project: FC<ProjectProps> = ({ project }) => (
       <ProjectLink href={project.github?.url} icon={<GitHub />} />
       <ProjectLink
         href={project.npm?.url}
-        icon={<FontAwesomeIcon icon={faNpm} />}
+        icon={<FontAwesomeIcon icon={faNpm} width={24} height={24} />}
       />
       <ProjectLink
         href={project.yarn?.url}
-        icon={<FontAwesomeIcon icon={faYarn} />}
+        icon={<FontAwesomeIcon icon={faYarn} width={24} height={24} />}
       />
       <ProjectLink href={project.ios?.url} icon={<Apple />} />
       <ProjectLink href={project.android?.url} icon={<Android />} />


### PR DESCRIPTION
The FontAwesome icons were rendering normally
when using the development server, however,
they were scaling too large when deployed to
GitHub Pages. This change restricts the width/height for the NPM and Yarn icons in the project cards.