### PR TITLE
fix(welcome): adjust margin around social links

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm test
+npm run lint && npm test

--- a/src/components/welcome/SocialLinks.tsx
+++ b/src/components/welcome/SocialLinks.tsx
@@ -9,7 +9,6 @@ import Link from "next/link";
 import { faEnvelope, faFilePdf } from "@fortawesome/free-solid-svg-icons";
 import { faLinkedin, faGithub } from "@fortawesome/free-brands-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import classNames from "classnames";
 
 const SOCIAL_LINK_ITEMS = [
   {
@@ -39,14 +38,14 @@ export const SocialLinks = () => {
       transition={{ delay: 0.5 }}
     >
       {SOCIAL_LINK_ITEMS.map(({ icon, url }) => (
-        <Link key={url} href={url} target="_blank" passHref>
-          <FontAwesomeIcon
-            icon={icon}
-            className={classNames(
-              "my-5 mx-3 w-5 h-5",
-              "hover:my-4 hover:mx-2.5 hover:w-6 hover:h-6 hover:brightness-75",
-            )}
-          />
+        <Link
+          key={url}
+          href={url}
+          target="_blank"
+          passHref
+          className="w-5 h-5 hover:w-6 hover:h-6 my-5 mx-3 hover:my-4 hover:mx-2.5 hover:brightness-75"
+        >
+          <FontAwesomeIcon icon={icon} className="w-full h-full" />
         </Link>
       ))}
     </motion.div>

--- a/src/components/welcome/Welcome.tsx
+++ b/src/components/welcome/Welcome.tsx
@@ -11,7 +11,7 @@ export const Welcome = () => {
     <div className="h-screen flex flex-col items-center justify-center">
       {isImageLoaded && (
         <div className="w-3/4 flex">
-          <div className="flex flex-col shrink items-center">
+          <div className="flex flex-col items-center">
             <WelcomeMessage />
             <SocialLinks />
           </div>


### PR DESCRIPTION
The margin on the actual icon was causing the links to have unnecessary clickable area around the icon. This was causing a strange experience where the user could click between icons and not actually get the desired link.